### PR TITLE
Add python3.7 compatability to server.py

### DIFF
--- a/pickups/server.py
+++ b/pickups/server.py
@@ -100,7 +100,18 @@ class Server:
                 conv = util.channel_to_conversation(channel, self._conv_list)
                 client.sent_messages.append(message[1:])
                 segments = hangups.ChatMessageSegment.from_str(message[1:])
-                asyncio.async(conv.send_message(segments))
+
+                # Ensure legacy compatability and python 3.7+ compatability
+                ensure_future = getattr(
+                    asyncio,
+                    'async',
+                    getattr(asyncio, "ensure_future", None)
+                )
+
+                if not ensure_future:
+                    raise AttributeError
+
+                ensure_future(conv.send_message(segments))
             elif line.startswith('JOIN'):
                 channel_line = line.split(' ')[1]
                 channels = channel_line.split(',')


### PR DESCRIPTION
@corcoran I'm relying on your fork of pickups as the original maintainer doesn't seem interested in accepting pull requests. I upgraded to python3.7 a few days ago and after restarting weechat, I couldn't use this tool anymore. I'm heavily reliant on it haha, so I figure it might be useful to others who are using the rolling release of python. 

